### PR TITLE
v2022.09.03

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2022.09.02
+FROM thorax/erigon:v2022.09.03
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
- Supports BSC `gibbs` fork on testnet
- POS Sync improvements