### PR TITLE
feature/OPS-1262-bump-erigon-image - Bump image version to v2.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.29.0
+FROM thorax/erigon:v2.30.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
# This PR: 
- Updates erigon image to include latest debug/trace [json serialization fixes](https://github.com/ledgerwatch/erigon/pull/6014/files)