### PR TITLE
feature/bump-erigon-version-to-v2.33.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.33.0
+FROM thorax/erigon:v2.33.1
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
Patch release. Compared to v2.33.0, contains only one change, fixing the trace_ RPC methods regression, introduced when implementing native tracers, and resulting in incorrect representation of SELFDESTRUCT traces