### PR TITLE
feature/bump-erigon-version-to-v2.34.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.33.1
+FROM thorax/erigon:v2.34.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
context: https://github.com/ledgerwatch/erigon/releases/tag/v2.34.0