### PR TITLE
feature/bump-erigon-version-to-v2.38.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.33.1
+FROM thorax/erigon:v2.38.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
- Gnosis Chain: Fixed trace_ RPC methods to not panic in certain cases for historical AuRa blocks.
- Improved handling of ForkChoiceUpdated.
- Bor: updated consensus engine code, presumably from “official” bor repository, by external contributor anshalshukla.
- Fixed a panic in the transaction pool during block composition.
- BSC: created a workaround for Erigon nodes lagging due to all other types of nodes (except Erigon) becoming passive, i.e. not propagating new block hashes or blocks, at least towards Erigon (this may be a bug in “official” BSC repo, but did not have time to investigate where it came from).
- Added support for eth/68 upgrade, which is one of the pre-requisites for EIP-4844 (blob transactions).