### PR TITLE
v2.47.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.45.1
+FROM thorax/erigon:v2.47.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
**Release highlights**

- Fixed regression introduced in release v2.45.0 and causing panic with message no gaps in tx ids are allowed. No resync is required, node repairs when run with this newest version.
- Added more block snapshots (up to block 44m) for Polygon bor mainnet.
- Support for Polygon Indore hard-fork (was also present in v2.46.0 which is now superseded).