### PR TITLE
feature/v2.50.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.49.1
+FROM thorax/erigon:v2.50.1
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
### Release Highlights

- erigon-lib is merged into erigon as subdirectory by @battlmonstr in https://github.com/ledgerwatch/erigon/pull/8201.
- [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) is fully implemented, including [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516): BLOBBASEFEE opcode.
- Initial implementation of Polygon [Milestones](https://forum.polygon.technology/t/proposal-improved-ux-with-milestones-for-polygon-pos/). Requires --bor.milestone to be set. If this is set Erigon will expect to connect to Heimdall v1.0.1. If it does not it will produce 404 errors each time it attempts a Milestone related RPC call.