### PR TITLE
feature/v2.51.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.50.2
+FROM thorax/erigon:v2.51.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
### Highlights
- Several fixes and improvements for Polygon
- Support go 1.21
- Experimental block execution using embedded Silkworm
- Fixed --internalcl flag
- Optimize gas by default in eth_createAccessList
- Fix another case of header download hanging (non-POS)
- Added block snapshot format (attempt for Caplin)
- Downloader: don't drop torrents after download (performance problem there solved)
- Downloader: move from snapshots/db to snapshots/downloader
- Remove protocolBaseFee checks