### PR TITLE
feature/v2.54.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.53.4
+FROM thorax/erigon:v2.54.0
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
### Release Highlights
- Added beacon snapshots download 
- bind-ipc 
- Enable h2c for http handler. add https handler for http2 
- config: avoid OOM in docker using cgroups v2 limit 
- fix: batch close confict with flush 
- snapshots: reduce merge limit of blocks to 100K
- mainnet 18.3M snaps 
- rlp2 
- Move validator set snapshot computation to bor_heimdall stage 
- add rollback tx at GetVoteOnHash 
- Discovery zero refresh timer
- headerdownload: handle tie breaker for forkchoice in pow networks 
- agra hf mainnet 
- defaults change: increase default --db.read.concurrency 4 times