### PR TITLE
feature/v2.56.1 - Bumps Erigon to v2.56.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.55.1
+FROM thorax/erigon:v2.56.1
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
# Changelog

[v2.56.0](https://github.com/ledgerwatch/erigon/releases/tag/v2.56.0)
[v2.56.1](https://github.com/ledgerwatch/erigon/releases/tag/v2.56.1)


# Summary
- These new releases mainly introduce new Goerli HF Dencun on Jan 17th
- Solves missing `txHash` issue on `debug_trace` requests https://github.com/ledgerwatch/erigon/pull/9016