### PR TITLE
v2.57.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.57.1
+FROM thorax/erigon:v2.57.3
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
### What's Changed

This release schedules the [Napoli](https://github.com/maticnetwork/Polygon-Improvement-Proposals/blob/main/PIPs/PIP-33.md) hard fork on the Mumbai test net at block 45648608 (Feb 7th, 2024 around 8 AM UTC). Mumbai operators must upgrade beforehand.