### PR TITLE
feat: Bumps erigon to v2.58.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.58.1
+FROM thorax/erigon:v2.58.2
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
## Description
- [x] Bumps Erigon version to v2.58.2

## Related Issue

## Motivation and Context
Blockchain Upgrades
Napoli HF on Polygon.
[**Changelog**](https://github.com/ledgerwatch/erigon/releases/tag/v2.58.2)

## How Has This Been Tested?
```docker
╰─$ docker build -t moraesjeremias/erigon:v2.58.2 .
[+] Building 1.4s (12/12) FINISHED                                                                                                                  docker:default
 => => naming to docker.io/moraesjeremias/erigon:v2.58.2
```

[moraesjeremias/erigon:v2.58.2](https://hub.docker.com/layers/moraesjeremias/erigon/v2.58.2/images/sha256-4e7790df90a584d9fd716c678488ce4a868612d34ac9ba19f1e14a159926dcaa?context=explore)

## Screenshots (if appropriate)
