### PR TITLE
feature/v2.59.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.59.0
+FROM thorax/erigon:v2.59.1
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
### [v2.59.1 Prep for block production in Caplin](https://github.com/ledgerwatch/erigon/releases/tag/v2.59.1)

What's Changed
- Caplin: Fixed not calling FCU due to faulty blob handling by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/9818
- fixed downloading of unnecessary blocks when --caplin.backfilling=f… by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/9820
- Proper Caplin's subscription listen by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/9821
- Added basic block production to Caplin by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/9822
- downloader: when torrent added to lib and metadata resolved - already… by @AskAlexSharov in https://github.com/ledgerwatch/erigon/pull/9823

Full Changelog: https://github.com/ledgerwatch/erigon/compare/v2.59.0...v2.59.1