### PR TITLE
v2.60.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.60.1
+FROM thorax/erigon:v2.60.2
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
[v2.60.2](https://github.com/ledgerwatch/erigon/releases/tag/v2.60.2) [Latest]

- Revert breaking change to eth_estimateGas introduced in v2.60.1 (https://github.com/ledgerwatch/erigon/pull/10904) as we added a better fix for gas fee calculation in debug calls by @mininny in https://github.com/ledgerwatch/erigon/pull/10880
- Fix potential p2p shutdown hangup by @mh0lt in https://github.com/ledgerwatch/erigon/pull/10626
- Downloader: fix staticpeers flag by @dvovk in https://github.com/ledgerwatch/erigon/pull/10798
- rpc: Fix incorrect txfeecap by @shohamc1 in https://github.com/ledgerwatch/erigon/pull/10643

Full Changelog: https://github.com/ledgerwatch/erigon/compare/v2.60.1...v2.60.2