### PR TITLE
bump to v2.60.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.io/library/golang:1.18-alpine3.15 AS builder
+FROM docker.io/library/golang:1.22-alpine3.20 AS builder
 
 WORKDIR /app/build/bin
-RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64 -P /app/build/bin/ && \
+RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.28/grpc_health_probe-linux-amd64 -P /app/build/bin/ && \
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.60.2
+FROM thorax/erigon:v2.60.4
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
## v2.60.2 -> v2.60.3
### Improvements:

- eth/tracers: add optional includePrecompiles flag to callTracer - default true is preserved by @taratorio in https://github.com/ledgerwatch/erigon/pull/10986
- turbo/jsonrpc: add optional includePrecompiles flag to trace_* apis by @taratorio in https://github.com/ledgerwatch/erigon/pull/10979

### Bugfixes:

- Changing Caplin Finality Checkpoint API response to match spec by @angusscott in https://github.com/ledgerwatch/erigon/pull/10944
- Caplin: Added Blob Sidecar PastFinalization Check by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/11006
- Less troublesome way of identifying content-type (https://github.com/ledgerwatch/erigon/pull/10770) by @Giulio2002 in https://github.com/ledgerwatch/erigon/pull/11018
- Allow to gracefully exit from CL downloading stage (https://github.com/ledgerwatch/erigon/pull/10887) by @awskii in https://github.com/ledgerwatch/erigon/pull/11020
- Add zero check in tx.Sender func by @somnathb1 in https://github.com/ledgerwatch/erigon/pull/10737
- eth/tracers: fix prestate tracer bug with create with value by @taratorio in https://github.com/ledgerwatch/erigon/pull/10960
- eth/tracers: always pop precompiles stack in callTracer by @taratorio in https://github.com/ledgerwatch/erigon/pull/11004
- Diagnostics: loglevel by @dvovk in https://github.com/ledgerwatch/erigon/pull/11015
- Diagnostics: Optimize db write by @dvovk in https://github.com/ledgerwatch/erigon/pull/11016

## v2.60.3 -> v2.60.4
### Changes
- PIP-35 for amoy: enforce 25gwei gas config for amoy for erigon 2 by @manav2401 in https://github.com/ledgerwatch/erigon/pull/11078