### PR TITLE
v2.60.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.60.2
+FROM thorax/erigon:v2.60.3
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
[v2.60.3](https://github.com/ledgerwatch/erigon/releases/tag/v2.60.3)

**Improvements**
- eth/tracers: add optional includePrecompiles flag to callTracer - default true is preserved 
- turbo/jsonrpc: add optional includePrecompiles flag to trace_* apis 

**Bugfixes**
- Changing Caplin Finality Checkpoint API response to match spec 
- Caplin: Added Blob Sidecar PastFinalization Check 
- Less troublesome way of identifying content-type 
- Allow to gracefully exit from CL downloading stage 
- Add zero check in tx.Sender func by @somnathb1 
- eth/tracers: fix prestate tracer bug with create with value 
- eth/tracers: always pop precompiles stack in callTracer 
- Diagnostics: loglevel by @dvovk 
- Diagnostics: Optimize db write 

Full Changelog: https://github.com/ledgerwatch/erigon/compare/v2.60.2...v2.60.3