### PR TITLE
v2.60.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.60.3
+FROM thorax/erigon:v2.60.4
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
**Release Changes**

This release of bor contains the updated implementation of PIP-35 which enforces the min gas values to 25 gwei. Please note that this is a recommended release for Amoy nodes running Bor and erigon client.