### PR TITLE
update base architecture image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM thorax/erigon:v2.60.5
+FROM thorax/erigon:2.60.5-amd64
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
**Changes**
The tag thorax/erigon:v2.60.5 is not available in upstream, so we are switching to thorax/erigon:2.60.5-amd64 instead. This image has already been tested locally.