### PR TITLE
amoy bump to v2.60.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM --platform=linux/amd64/v2 erigontech/erigon:2.60.7
+FROM --platform=linux/amd64/v2 erigontech/erigon:2.60.8
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
**Highlights**
- This release schedules the [Ahmedabad hardfork](https://forum.polygon.technology/t/pip-37-ahmedabad-hardfork) for the Polygon mainnet and the [Gandhinagar hardfork](https://forum.polygon.technology/t/bor-v1-4-0-beta2-amoy-release-gandhinagar-hardfork) for Amoy. Thus it's mandatory for all Polygon users.
- This release also fixes Issue https://github.com/erigontech/erigon/issues/11936 debug trace RPC error in Polygon Amoy.

Full Changelog: https://github.com/erigontech/erigon/compare/2.60.7...2.60.8