### PR TITLE
Erigon Bump up to v2.61.1 (Pectra hardfork)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM --platform=linux/amd64/v2 erigontech/erigon:v2.61.0
+FROM --platform=linux/amd64/v2 erigontech/erigon:v2.61.1
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
https://github.com/erigontech/erigon/releases/tag/v2.61.1

Holesky and Sepolia users: this is a required update for the upcoming Pectra hardfork.

Pectra scheduled for:
- Holesky: Mon, Feb 24 at 21:55:12 UTC
- Sepolia: Wed, Mar 5 at 07:29:36 UTC