### PR TITLE
Erigon bumped up to v2.61.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v
     mv /app/build/bin/grpc_health_probe-linux-amd64 /app/build/bin/grpc_health_probe && \
     chmod +x /app/build/bin/grpc_health_probe
 
-FROM --platform=linux/amd64/v2 erigontech/erigon:v2.61.1
+FROM --platform=linux/amd64/v2 erigontech/erigon:v2.61.3
 COPY --from=builder /app/build/bin/* /usr/local/bin/


### PR DESCRIPTION
Mandatory for Sepolia & Chiado

Bugfixes:

Pectra: fix bad deposit contract deposit unmarshalling in https://github.com/erigontech/erigon/pull/14074

Details: https://github.com/erigontech/erigon/releases/tag/v2.61.3